### PR TITLE
Django 2.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ env:
     - DJANGO=">=1.10,<1.11"
     - DJANGO=">=1.11,<2.0"
     - DJANGO=">=2.0,<2.1"
+matrix:
+  exclude:
+  - python: 2.7
+    env: DJANGO=">=2.0,<2.1"
 install:
   - pip install -q coverage flake8 Django$DJANGO django-nose>=1.4
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - DJANGO=">=1.9,<1.10"
     - DJANGO=">=1.10,<1.11"
     - DJANGO=">=1.11,<2.0"
+    - DJANGO=">=2.0,<2.1"
 install:
   - pip install -q coverage flake8 Django$DJANGO django-nose>=1.4
 before_script:

--- a/dynamic_initial_data/base.py
+++ b/dynamic_initial_data/base.py
@@ -173,7 +173,7 @@ class InitialDataUpdater(object):
         for receipt in RegisteredForDeletionReceipt.objects.exclude(register_time=now):
             try:
                 receipt.model_obj.delete()
-            except:
+            except:  # noqa
                 # The model object may no longer be there, its ctype may be invalid, or it might be protected.
                 # Regardless, the model object cannot be deleted, so go ahead and delete its receipt.
                 pass

--- a/dynamic_initial_data/migrations/0001_initial.py
+++ b/dynamic_initial_data/migrations/0001_initial.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):

--- a/dynamic_initial_data/migrations/0001_initial.py
+++ b/dynamic_initial_data/migrations/0001_initial.py
@@ -17,7 +17,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', primary_key=True, serialize=False, auto_created=True)),
                 ('model_obj_id', models.PositiveIntegerField()),
                 ('register_time', models.DateTimeField()),
-                ('model_obj_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('model_obj_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='contenttypes.ContentType')),
             ],
             options={
             },

--- a/dynamic_initial_data/models.py
+++ b/dynamic_initial_data/models.py
@@ -10,7 +10,7 @@ class RegisteredForDeletionReceipt(models.Model):
     initial data process.
     """
     # The model object that was registered
-    model_obj_type = models.ForeignKey(ContentType)
+    model_obj_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     model_obj_id = models.PositiveIntegerField()
     model_obj = GenericForeignKey('model_obj_type', 'model_obj_id', for_concrete_model=False)
 


### PR DESCRIPTION
@wesokes @jaredlewis Django 2.0 requires an `on_delete` argument for all foreign keys. I believe this is all that is needed for the 2.0 upgrade on this package